### PR TITLE
fix for chrome

### DIFF
--- a/Source/Mouse2Touch.js
+++ b/Source/Mouse2Touch.js
@@ -7,6 +7,7 @@ license: MIT-style
 authors:
 - Chi Wai Lau (http://tabqwert.com)
 - Scott Kyle (http://appden.com)
+- Bram Loogman
 
 requires:
 - core/1.2.4: '*'
@@ -20,7 +21,7 @@ provides: [Mouse2Touch]
   } catch(e) {
     return;
   }
-
+  
   ['touchstart', 'touchmove', 'touchend'].each(function(type){
       Element.NativeEvents[type] = 2;
   });
@@ -30,20 +31,12 @@ provides: [Mouse2Touch]
     'mousemove': 'touchmove',
     'mouseup': 'touchend'
   };
-
-  var condition = function(event) {
-    var touch = event.event.changedTouches[0];
-    event.page = {
-      x: touch.pageX,
-      y: touch.pageY
+    
+  Object.each(mapping, function(touch, mouse) { 
+    Element.Events[mouse] = {
+	  onAdd: function(fn) {
+        this.addEvent(touch, fn);
+	  }
     };
-    return true;
-  };
-
-  for (var e in mapping) {
-    Element.Events[e] = {
-      base: mapping[e],
-      condition: condition
-    };
-  }
+  });  
 })();

--- a/Source/Mouse2Touch.js
+++ b/Source/Mouse2Touch.js
@@ -32,11 +32,31 @@ provides: [Mouse2Touch]
     'mouseup': 'touchend'
   };
     
-  Object.each(mapping, function(touch, mouse) { 
+  Object.each(mapping, function(touch, mouse) {
+    Element.Events[touch] = {
+       condition: function(e) {
+         var useTouch = this.retrieve('useTouch');
+         if (!useTouch) return false;
+         useTouch[mouse]++;
+         return true;
+       }
+    }
     Element.Events[mouse] = {
-	  onAdd: function(fn) {
+      condition: function(e) {
+        var useTouch = this.retrieve('useTouch');  
+        if (!useTouch || !useTouch[mouse]) return true;
+        useTouch[mouse]--;
+        return false;
+      },
+      onAdd: function(fn) {
+        var useTouch = this.retrieve('useTouch', {});
+        if (!useTouch[mouse]) useTouch[mouse] = 0;
         this.addEvent(touch, fn);
-	  }
+        
+      },
+      onRemove: function(fn) {
+        this.removeEvent(touch, fn);
+      }
     };
   });  
 })();

--- a/package.yml
+++ b/package.yml
@@ -1,4 +1,3 @@
----
 name: Mouse2Touch
 author: clau
 category: Utilities
@@ -6,3 +5,6 @@ tags: [iphone, ipad, safari, multitouch]
 docs: http://tabqwerty.com/2010/04/08/supporting-mouse-events-in-mobile-safari.html
 demo: http://www.mikematas.com
 current: 0.1
+
+sources:
+  - "Source/Mouse2Touch.js"


### PR DESCRIPTION
because chrome supports the touch events, mouse events will be overwritten
to fix this i suggest to attach the event handlers for mouse events also to the corresponding touch event
